### PR TITLE
Cert fix on unifiOS start

### DIFF
--- a/unifi-osserver-ssl-import
+++ b/unifi-osserver-ssl-import
@@ -236,8 +236,8 @@ echo "✅"
 
 # Set permissions
 echo -n "Setting permissions... "
-chmod 600 "${DEST_KEY}" "${DEST_CERT}"
-chown uosserver:uosserver "${DEST_KEY}" "${DEST_CERT}" 2>/dev/null || echo "chown failed"
+chmod 640 "${DEST_KEY}" "${DEST_CERT}"
+chown root:uosserver "${DEST_KEY}" "${DEST_CERT}" 2>/dev/null || echo "chown failed"
 echo "✅"
 
 # Save new checksum


### PR DESCRIPTION
stop UnifiOS overwriting our new SSL on start